### PR TITLE
Add a --warnings option

### DIFF
--- a/py-doc-to-xml/README.md
+++ b/py-doc-to-xml/README.md
@@ -43,6 +43,12 @@ Run the tool:
 python main.py translate --doc-file input.docx --output-file output.xml
 ```
 
+To see a description of the available options, run
+
+```bash
+python main.py translate --help
+```
+
 ## Developer Guide
 
 ### XML Serialization Generation

--- a/py-doc-to-xml/docx_to_xml/doc1.py
+++ b/py-doc-to-xml/docx_to_xml/doc1.py
@@ -26,7 +26,9 @@ def check_for_duplicate(domain_list: List[SemanticDomain], item: SemanticDomain)
     return next((x for x in domain_list if x.number == item.number), None) is not None
 
 
-def parse_semantic_domains(body: List[DocModel],*, use_warnings: bool = False) -> List[SemanticDomain]:
+def parse_semantic_domains(
+    body: List[DocModel], *, use_warnings: bool = False
+) -> List[SemanticDomain]:
     """
     Convert a list of DocModel elements into a list of SemanticDomain elements.
 
@@ -114,7 +116,10 @@ def parse_semantic_domains(body: List[DocModel],*, use_warnings: bool = False) -
             process_error(f"Unexpected element in body: {paragraph}", use_warnings)
 
         if paragraph.style and "numPr" in paragraph.style:
-            process_error(f"Automatic numbering: {paragraph}; Current semantic domain{current_semantic_domain}", use_warnings)
+            process_error(
+                f"Automatic numbering: {paragraph}; Current semantic domain{current_semantic_domain}",
+                use_warnings,
+            )
 
         values = paragraph.VALUE
         values_count = len(values)
@@ -131,7 +136,9 @@ def parse_semantic_domains(body: List[DocModel],*, use_warnings: bool = False) -
             # if the current semantic domain element is valid, add it to the list
             if current_semantic_domain.is_valid():
                 if check_for_duplicate(semantic_domains, current_semantic_domain):
-                    process_error(f"Duplicate Domain: {current_semantic_domain.number}", use_warnings)
+                    process_error(
+                        f"Duplicate Domain: {current_semantic_domain.number}", use_warnings
+                    )
                 semantic_domains.append(current_semantic_domain)
             (domain_number, domain_title) = split_semantic_domain_line(value)
             current_semantic_domain = SemanticDomain(
@@ -160,7 +167,13 @@ def parse_semantic_domains(body: List[DocModel],*, use_warnings: bool = False) -
     return semantic_domains
 
 
-def process_doc(doc: DocModel, output_file: Optional[Path] = None, *, start_index: int = 0, warnings: bool = False) -> None:
+def process_doc(
+    doc: DocModel,
+    output_file: Optional[Path] = None,
+    *,
+    start_index: int = 0,
+    warnings: bool = False,
+) -> None:
     """Document-specific steps."""
     assert doc.TYPE == "document"
     body = doc.VALUE[0]

--- a/py-doc-to-xml/main.py
+++ b/py-doc-to-xml/main.py
@@ -25,13 +25,14 @@ def translate(
     ),
     output_file: Path = Option(..., "--output-file", "-o", writable=True, resolve_path=True),
     debug_file: Optional[Path] = Option(writable=True, resolve_path=True, default=None),
+    warnings: bool = Option(False, "--warnings", "-w")
 ) -> None:
     doc = Document(doc_file)
     json = simplify(doc, {"include-paragraph-indent": False, "include-paragraph-numbering": True})
     if debug_file is not None:
         debug_file.write_text(pformat(json))
     doc_model: DocModel = DocModel.parse_obj(json)
-    process_doc(doc_model, output_file)
+    process_doc(doc_model, output_file, warnings=warnings)
 
 
 @app.command()

--- a/py-doc-to-xml/main.py
+++ b/py-doc-to-xml/main.py
@@ -21,11 +21,35 @@ app = Typer(add_completion=False)
 @app.command()
 def translate(
     doc_file: Path = Option(
-        ..., "--doc-file", "-d", exists=True, dir_okay=False, readable=True, resolve_path=True
+        ...,
+        "--doc-file",
+        "-d",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+        help="Input document file in .docx format",
     ),
-    output_file: Path = Option(..., "--output-file", "-o", writable=True, resolve_path=True),
-    debug_file: Optional[Path] = Option(writable=True, resolve_path=True, default=None),
-    warnings: bool = Option(False, "--warnings", "-w")
+    output_file: Path = Option(
+        ...,
+        "--output-file",
+        "-o",
+        writable=True,
+        resolve_path=True,
+        help="Output file for the Semantic Domain XML file",
+    ),
+    debug_file: Optional[Path] = Option(
+        writable=True,
+        resolve_path=True,
+        default=None,
+        help="Debug output file to capture the JSON file representation of the input document contents",
+    ),
+    warnings: bool = Option(
+        False,
+        "--warnings",
+        "-w",
+        help="Print warnings on standard error instead of raising an exception when a parsing problem is found.",
+    ),
 ) -> None:
     doc = Document(doc_file)
     json = simplify(doc, {"include-paragraph-indent": False, "include-paragraph-numbering": True})

--- a/py-doc-to-xml/semantic_domain_subs.py
+++ b/py-doc-to-xml/semantic_domain_subs.py
@@ -23,6 +23,7 @@ import os
 import sys
 
 from lxml import etree as etree_
+
 import semantic_domain as supermod
 
 


### PR DESCRIPTION
When the --warnings (or -w) option is specified, the script will print a
warning on stderr when an error is detected instead of raising an
exception.